### PR TITLE
Update CircleCI config to deploy on commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,21 +51,3 @@ workflows:
         filters:
           branches:
             only: master
-  nightly:
-    triggers:
-    - schedule:
-        cron: "0 8 * * *"
-        filters:
-          branches:
-            only: master
-    jobs:
-    - build
-    - test:
-        requires:
-        - build
-    - deploy:
-        requires:
-        - test
-        filters:
-          branches:
-            only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,12 @@ workflows:
     - test:
         requires:
         - build
+    - deploy:
+        requires:
+        - test
+        filters:
+          branches:
+            only: master
   nightly:
     triggers:
     - schedule:


### PR DESCRIPTION
Right now, CircleCI is set to deploy to Firebase every night in the "nightly" workflow. It turns out that the API calls that `api-data` and `pokeapi.co` projects use actually trigger the "commit" workflow, which is not set to deploy to Firebase.

These changes remove the the nightly workflow in favour of deploying to Firebase on commit (or when the API is used to trigger the commit workflow). This will let us commit a change to either `pokepai.co` or `api-data` (via the updater) and see it live within a few minutes.