### PR TITLE
Use node 8 as engine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,16 +6,16 @@ jobs:
     - image: circleci/node:10.11.0
     steps:
     - checkout
-    - run: yarn --cwd functions install
-    - run: yarn --cwd functions run lint
-    - run: yarn --cwd functions run build
+    - run: yarn --ignore-engines --cwd functions install
+    - run: yarn --ignore-engines --cwd functions run lint
+    - run: yarn --ignore-engines --cwd functions run build
 
   test:
     docker:
     - image: circleci/node:10.11.0
     steps:
     - checkout
-    - run: yarn --cwd functions
+    - run: yarn --ignore-engines --cwd functions
     # TODO: write some tests and run them here
 
   deploy:
@@ -34,7 +34,7 @@ jobs:
     - run: tar xzf static_website.tar.gz -C public
 
     # Deploy to Firebase
-    - run: yarn --cwd functions install
+    - run: yarn --ignore-engines --cwd functions install
     - run: functions/node_modules/.bin/firebase deploy --token=$FIREBASE_DEPLOY_TOKEN --project=$FIREBASE_PROJECT_ID
 
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,8 +1,8 @@
 {
   "functions": {
     "predeploy": [
-      "yarn --cwd \"$RESOURCE_DIR\" run lint",
-      "yarn --cwd \"$RESOURCE_DIR\" run build"
+      "yarn --ignore-engines --cwd \"$RESOURCE_DIR\" run lint",
+      "yarn --ignore-engines --cwd \"$RESOURCE_DIR\" run build"
     ]
   },
   "hosting": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -10,6 +10,9 @@
     "logs": "firebase functions:log"
   },
   "main": "lib/index.js",
+  "engines": {
+    "node": "8"
+  },
   "dependencies": {
     "axios": "^0.19.2",
     "compression": "^1.7.4",


### PR DESCRIPTION
Fix deployment and forces Node 8 to be used by Firebase functions.

```
Error: There was an error reading functions/package.json:

 Engines field is required but was not found in functions/package.json.
To fix this, add the following lines to your package.json: 

      "engines": {
        "node": "8"
      }
```

https://app.circleci.com/pipelines/github/PokeAPI/deploy/72/workflows/3e0ea22d-1f46-4943-b2ac-3b09984922f2/jobs/313