### PR TITLE
Enable staging deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,6 @@ workflows:
       - deploy:
           requires:
             - test
-          # filters: # TODO: uncomment
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,20 +23,7 @@ jobs:
     - image: circleci/node:10.11.0
     steps:
     - checkout
-    - run: mkdir -p public
-
-    # Get stored artifacts from api-data and unpack into the 'public' directory
-    - run: wget $(curl -s 'https://circleci.com/api/v1.1/project/github/PokeAPI/api-data/latest/artifacts?branch=master' | jq -r .[0].url)
-    - run: tar xzf _gen.tar.gz -C public
-
-    # Get stored artifacts from pokeapi.co and unpack into the current directory
-    - run: wget $(curl -s 'https://circleci.com/api/v1.1/project/github/PokeAPI/pokeapi.co/latest/artifacts?branch=master' | jq -r .[0].url)
-    - run: tar xzf static_website.tar.gz -C public
-
-    # Deploy to Firebase
-    - run: yarn --ignore-engines --cwd functions install
-    - run: functions/node_modules/.bin/firebase deploy --token=$FIREBASE_DEPLOY_TOKEN --project=$FIREBASE_PROJECT_ID
-
+    - run: sh scripts/deploy.sh
 
 workflows:
   version: 2
@@ -49,6 +36,6 @@ workflows:
     - deploy:
         requires:
         - test
-        filters:
-          branches:
-            only: master
+        # filters: # TODO: uncomment
+        #   branches:
+        #     only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,41 +1,45 @@
-version: 2
+version: 2.1
+
+executors:
+  node10:
+    docker:
+      - image: circleci/node:10.11.0
 
 jobs:
   build:
-    docker:
-    - image: circleci/node:10.11.0
+    executor: node10
     steps:
-    - checkout
-    - run: yarn --ignore-engines --cwd functions install
-    - run: yarn --ignore-engines --cwd functions run lint
-    - run: yarn --ignore-engines --cwd functions run build
+      - checkout
+      - run: yarn --ignore-engines --cwd functions install
+      - run: yarn --ignore-engines --cwd functions run lint
+      - run: yarn --ignore-engines --cwd functions run build
 
   test:
-    docker:
-    - image: circleci/node:10.11.0
+    executor: node10
     steps:
-    - checkout
-    - run: yarn --ignore-engines --cwd functions
-    # TODO: write some tests and run them here
+      - checkout
+      - run: yarn --ignore-engines --cwd functions
+      # TODO: write some tests and run them here
 
   deploy:
-    docker:
-    - image: circleci/node:10.11.0
+    executor: node10
     steps:
-    - checkout
-    - run: sh -x scripts/deploy.sh
+      - checkout
+      - run:
+          name: Deploy website and api-data to the correct environment (production/staging)
+          command: sh -x scripts/deploy.sh
 
 workflows:
   version: 2
   commit:
     jobs:
-    - build
-    - test:
-        requires:
-        - build
-    - deploy:
-        requires:
-        - test
-        # filters: # TODO: uncomment
-        #   branches:
-        #     only: master
+      - build
+      - test:
+          requires:
+            - build
+      - deploy:
+          requires:
+            - test
+          # filters: # TODO: uncomment
+          #   branches:
+          #     only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
     - image: circleci/node:10.11.0
     steps:
     - checkout
-    - run: sh scripts/deploy.sh
+    - run: sh -x scripts/deploy.sh
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-public/_gen/
+public/
 functions/lib/
+*.tar.gz
 
 # Created by https://www.gitignore.io/api/node,firebase,webstorm+all
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,7 +6,7 @@ import * as functions from "firebase-functions";
 import * as status from "http-status-codes"
 
 
-const BASE_URL = "https://pokeapi-test-b6137.firebaseapp.com/"; // TODO: support also https://pokeapi-215911.firebaseapp.com conditionally
+const BASE_URL = "https://pokeapi-test-b6137.firebaseapp.com"; // TODO: support also https://pokeapi-215911.firebaseapp.com conditionally
 
 function targetUrlForPath(path) {
     let target = BASE_URL;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,7 +6,7 @@ import * as functions from "firebase-functions";
 import * as status from "http-status-codes"
 
 
-const BASE_URL = "https://pokeapi.co"; // TODO: support also https://pokeapi-215911.firebaseapp.com conditionally
+const BASE_URL = "https://pokeapi-test-b6137.firebaseapp.com/"; // TODO: support also https://pokeapi-215911.firebaseapp.com conditionally
 
 function targetUrlForPath(path) {
     let target = BASE_URL;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5,8 +5,12 @@ import * as express from "express";
 import * as functions from "firebase-functions";
 import * as status from "http-status-codes"
 
+const config = functions.config();
+let BASE_URL = "https://pokeapi.co";
 
-const BASE_URL = "https://pokeapi-test-b6137.firebaseapp.com"; // TODO: support also https://pokeapi-215911.firebaseapp.com conditionally
+if (config.network && config.network.base_url) {
+    BASE_URL = config.network.base_url; // To retrieve the config run: `firebase functions:config:get --project <PROJECT_ID>`
+}
 
 function targetUrlForPath(path) {
     let target = BASE_URL;

--- a/scripts/add_baseurl_firebase.sh
+++ b/scripts/add_baseurl_firebase.sh
@@ -1,0 +1,7 @@
+#!/bin/dontexecute
+# This script is not intended to be executed
+# It is intended to document how to update the configuration of Firebase
+
+# Adds BASE_URL to FireBase config
+firebase functions:config:set network.base_url="https://pokeapi-test-b6137.firebaseapp.com" --project "<PROJECT_ID>"
+firebase functions:config:set network.base_url="https://pokeapi.co" --project "<PROJECT_ID>"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,7 +18,7 @@ fi
 mkdir -p public
 
 # Get stored artifacts from api-data and unpack into the 'public' directory
-wget -O '_gen.tar.gz' --no-check-certificate "$(curl -s https://circleci.com/api/v1.1/project/github/PokeAPI/api-data/latest/artifacts?branch=${deploy_location} | jq -r .[0].url)"
+wget -O '_gen.tar.gz' "$(curl -s https://circleci.com/api/v1.1/project/github/PokeAPI/api-data/latest/artifacts?branch=${deploy_location} | jq -r .[0].url)"
 if [ $? -ne 0 ]; then
     echo "Couldn't find the latest api-data .tar.gz for the branch ${deploy_location}"
     exit 1
@@ -26,7 +26,7 @@ fi
 tar xzf _gen.tar.gz -C public
 
 # Get stored artifacts from pokeapi.co and unpack into the current directory
-wget -O 'static_website.tar.gz' --no-check-certificate "$(curl -s https://circleci.com/api/v1.1/project/github/PokeAPI/pokeapi.co/latest/artifacts?branch=${deploy_location} | jq -r .[0].url)"
+wget -O 'static_website.tar.gz' "$(curl -s https://circleci.com/api/v1.1/project/github/PokeAPI/pokeapi.co/latest/artifacts?branch=${deploy_location} | jq -r .[0].url)"
 if [ $? -ne 0 ]; then
     echo "Couldn't find the latest pokeapi.co website .tar.gz for the branch ${deploy_location}"
     exit 1

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# Executed when the `master` or `staging` branches of PokeAPI/api-data and PokeAPI/pokeapi.co are pushed to
+# Runs in CircleCI
+# Deploys both pokeapi.co and api-data to Firebase in the respective project
+# $FIREBASE_DEPLOY_TOKEN, $FIREBASE_PROJECT_ID, $FIREBASE_DEPLOY_TOKEN_STAGING, $FIREBASE_PROJECT_ID_STAGING are present in CircleCI
+# $deploy_location is an environment variable set when the job is triggered by one of the two repositories getting pushed
+
+deploy_location='staging'
+
+if [ "${deploy_location:=master}" = 'master' ]; then # https://stackoverflow.com/a/2013589/3482533
+    TOKEN=${FIREBASE_DEPLOY_TOKEN}
+    PROJECT=${FIREBASE_PROJECT_ID}
+elif [ "${deploy_location}" = 'staging' ]; then
+    TOKEN=${FIREBASE_DEPLOY_TOKEN_STAGING}
+    PROJECT=${FIREBASE_PROJECT_ID_STAGING}
+fi
+
+mkdir -p public
+
+deploy_location='master'
+
+# Get stored artifacts from api-data and unpack into the 'public' directory
+wget -O '_gen.tar.gz' --no-check-certificate "$(curl -s https://circleci.com/api/v1.1/project/github/PokeAPI/api-data/latest/artifacts?branch=${deploy_location} | jq -r .[0].url)"
+tar xzf _gen.tar.gz -C public
+
+# Get stored artifacts from pokeapi.co and unpack into the current directory
+wget -O 'static_website.tar.gz' --no-check-certificate "$(curl -s https://circleci.com/api/v1.1/project/github/PokeAPI/pokeapi.co/latest/artifacts?branch=${deploy_location} | jq -r .[0].url)"
+tar xzf static_website.tar.gz -C public
+
+# Deploy to Firebase
+yarn --ignore-engines --cwd functions install
+functions/node_modules/.bin/firebase deploy --token="${TOKEN}" --project="${PROJECT}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -19,10 +19,18 @@ mkdir -p public
 
 # Get stored artifacts from api-data and unpack into the 'public' directory
 wget -O '_gen.tar.gz' --no-check-certificate "$(curl -s https://circleci.com/api/v1.1/project/github/PokeAPI/api-data/latest/artifacts?branch=${deploy_location} | jq -r .[0].url)"
+if [ $? -ne 0 ]; then
+    echo "Couldn't find the latest api-data .tar.gz for the branch ${deploy_location}"
+    exit 1
+fi
 tar xzf _gen.tar.gz -C public
 
 # Get stored artifacts from pokeapi.co and unpack into the current directory
 wget -O 'static_website.tar.gz' --no-check-certificate "$(curl -s https://circleci.com/api/v1.1/project/github/PokeAPI/pokeapi.co/latest/artifacts?branch=${deploy_location} | jq -r .[0].url)"
+if [ $? -ne 0 ]; then
+    echo "Couldn't find the latest pokeapi.co website .tar.gz for the branch ${deploy_location}"
+    exit 1
+fi
 tar xzf static_website.tar.gz -C public
 
 # Deploy to Firebase

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,7 +5,7 @@
 # $FIREBASE_DEPLOY_TOKEN, $FIREBASE_PROJECT_ID, $FIREBASE_DEPLOY_TOKEN_STAGING, $FIREBASE_PROJECT_ID_STAGING are present in CircleCI
 # $deploy_location is an environment variable set when the job is triggered by one of the two repositories getting pushed
 
-if [ "${deploy_location:=staging}" = 'master' ]; then # https://stackoverflow.com/a/2013589/3482533
+if [ "${deploy_location:=master}" = 'master' ]; then # https://stackoverflow.com/a/2013589/3482533
     echo 'Deploying master branches of PokeAPI/api-data and PokeAPI/pokeapi.co to https://pokeapi.co'
     TOKEN=${FIREBASE_DEPLOY_TOKEN}
     PROJECT=${FIREBASE_PROJECT_ID}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -6,9 +6,11 @@
 # $deploy_location is an environment variable set when the job is triggered by one of the two repositories getting pushed
 
 if [ "${deploy_location:=staging}" = 'master' ]; then # https://stackoverflow.com/a/2013589/3482533
+    echo 'Deploying master branches of PokeAPI/api-data and PokeAPI/pokeapi.co to https://pokeapi.co'
     TOKEN=${FIREBASE_DEPLOY_TOKEN}
     PROJECT=${FIREBASE_PROJECT_ID}
 elif [ "${deploy_location}" = 'staging' ]; then
+    echo 'Deploying staging branches of PokeAPI/api-data and PokeAPI/pokeapi.co to the staging location'
     TOKEN=${FIREBASE_DEPLOY_TOKEN_STAGING}
     PROJECT=${FIREBASE_PROJECT_ID_STAGING}
 fi

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,9 +5,7 @@
 # $FIREBASE_DEPLOY_TOKEN, $FIREBASE_PROJECT_ID, $FIREBASE_DEPLOY_TOKEN_STAGING, $FIREBASE_PROJECT_ID_STAGING are present in CircleCI
 # $deploy_location is an environment variable set when the job is triggered by one of the two repositories getting pushed
 
-deploy_location='staging'
-
-if [ "${deploy_location:=master}" = 'master' ]; then # https://stackoverflow.com/a/2013589/3482533
+if [ "${deploy_location:=staging}" = 'master' ]; then # https://stackoverflow.com/a/2013589/3482533
     TOKEN=${FIREBASE_DEPLOY_TOKEN}
     PROJECT=${FIREBASE_PROJECT_ID}
 elif [ "${deploy_location}" = 'staging' ]; then
@@ -16,8 +14,6 @@ elif [ "${deploy_location}" = 'staging' ]; then
 fi
 
 mkdir -p public
-
-deploy_location='master'
 
 # Get stored artifacts from api-data and unpack into the 'public' directory
 wget -O '_gen.tar.gz' --no-check-certificate "$(curl -s https://circleci.com/api/v1.1/project/github/PokeAPI/api-data/latest/artifacts?branch=${deploy_location} | jq -r .[0].url)"


### PR DESCRIPTION
This PR enables a conditional _deploy_ job on CircleCI so that we will have a productive environment and a staging one. This will allow us to check all the APIs and the website in a separate environment, and, if everything seems right, to deploy safely to https://pokeapi.co/.

A more descriptive and general overview is detailed in this https://github.com/PokeAPI/pokeapi/pull/488 PR.

This _deploy_ job will be mostly invoked by API calls done by `pokeapi.co` and `api-data`. This job will deploy to the productive Firebase (pokeapi.co) if this repo gets pushed or if the `master` branch of either `pokeapi.co` or `api-data` is pushed. When deploying it will always use `pokeapi.co` and `api-data`'s artifacts based on their `master` branches.

When the branch `staging` of either `pokeapi.co` or `api-data` will be pushed then the job will deploy the artifacts based on their aforementioned `staging` branches to a new Firebase staging environment (https://pokeapi-test-b6137.firebaseapp.com) (I will give access to @phalt, @tdmalone, @cmmartti to this Firebase project). It would be also nice if @phalt could create the subdomain `staging.pokeapi.co` and link it to the Firebase project. To do so we should create the new domain, add a `TXT` record type with `host` equal to _pokeapi.co_ and `value` equal to _google-site-verification=gV4NnTbUxNds2dIATNVlEyHCfWBgOjte2cNuAdlIVA0_. Then probably we need to add the Firebase nameservers to the Namecheap domain config. I will also need to change some strings here and there in the PR I just opened.

![txt](https://user-images.githubusercontent.com/8996268/80892979-a05fb580-8cce-11ea-9e9a-1880e9ce348b.PNG)

---

This PR is linked to the following PRs: 
- https://github.com/PokeAPI/pokeapi.co/pull/76 
- https://github.com/PokeAPI/api-data/pull/42 
- https://github.com/PokeAPI/pokeapi/pull/488

This PR should be the first to be merged among them.